### PR TITLE
Auto-generate pages.json file by expanding a Jinja2 template

### DIFF
--- a/app/service/database/generate-page-definitions.py
+++ b/app/service/database/generate-page-definitions.py
@@ -1,0 +1,87 @@
+from jinja2 import Template
+import os
+import json
+
+regions = [
+    {'abbreviation': "sco",
+     'shortname': "scotland",
+     'displayname': "Scotland"
+     },
+    {'abbreviation': "aa",
+     'shortname': "nhs_ayrshire_arran",
+     'displayname': "NHS Ayrshire & Arran"
+     },
+    {'abbreviation': "bpr",
+     'shortname': "nhs_borders",
+     'displayname': "NHS Borders"
+     },
+    {'abbreviation': "dg",
+     'shortname': "nhs_dumfries_galloway",
+     'displayname': "NHS Dumfries & Galloway"
+     },
+    {'abbreviation': "fif",
+     'shortname': "nhs_fife",
+     'displayname': "NHS Fife"
+     },
+    {'abbreviation': "fov",
+     'shortname': "nhs_forth_valley",
+     'displayname': "NHS Forth Valley"
+     },
+    {'abbreviation': "gc",
+     'shortname': "nhs_greater_glasgow_clyde",
+     'displayname': "NHS Greater Glasgow & Clyde"
+     },
+    {'abbreviation': "golden",
+     'shortname': "golden_jubilee_nationalhospital",
+     'displayname': "Golden Jubilee National Hospital"
+     },
+    {'abbreviation': "gra",
+     'shortname': "nhs_grampian",
+     'displayname': "NHS Grampian"
+     },
+    {'abbreviation': "hig",
+     'shortname': "nhs_highland",
+     'displayname': "NHS Highland"
+     },
+    {'abbreviation': "lan",
+     'shortname': "nhs_lanarkshire",
+     'displayname': "NHS Lanarkshire"
+     },
+    {'abbreviation': "lot",
+     'shortname': "nhs_lothian",
+     'displayname': "NHS Lothian"
+     },
+    {'abbreviation': "ork",
+     'shortname': "nhs_orkney",
+     'displayname': "NHS Orkney"
+     },
+    {'abbreviation': "she",
+     'shortname': "nhs_shetland",
+     'displayname': "NHS Shetland"
+     },
+    {'abbreviation': "tay",
+     'shortname': "nhs_tayside",
+     'displayname': "NHS Tayside"
+     },
+    {'abbreviation': "wei",
+     'shortname': "nhs_western_isles_scotland",
+     'displayname': "NHS Western Isles"
+     }
+]
+
+basedir = os.path.dirname(os.path.abspath(__file__))
+
+
+with open(os.path.join(basedir, 'pages.template')) as f:
+    template_string = f.readlines()
+    template = Template("\n".join(template_string))
+
+with open(os.path.join(basedir, 'pages.json'), 'w') as f:
+    result_string = template.render(regions=regions)
+
+    # print direct output of template
+    # NB. works even if JSON is malformed, so useful for debugging
+    # f.write(template.render(regions=regions))
+
+    # Auto-indents JSON
+    json.dump(json.loads(result_string), f, indent=2)

--- a/app/service/database/pages.json
+++ b/app/service/database/pages.json
@@ -1,17 +1,56 @@
-  [
+[
   {
     "id": 1,
     "name": "top-level-overview-screen-a",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 1, "data_id": 1, "query_params": { "table": "cumulative_cases" }, "title": "" }
+      {
+        "vis_id": 1,
+        "data_id": 1,
+        "query_params": {
+          "table": "cumulative_cases"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Cumulative Number of Cases Tested Positive for COVID-19",
     "description": "The cumulative number of cases with positive tests for COVID-19, by board in Scotland",
     "links": {
-                "regional": [3, 7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62],
-                "board": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80]
+      "regional": [
+        3,
+        7,
+        11,
+        15,
+        19,
+        23,
+        34,
+        27,
+        38,
+        42,
+        46,
+        50,
+        54,
+        58,
+        62
+      ],
+      "board": [
+        2,
+        66,
+        67,
+        68,
+        69,
+        70,
+        73,
+        71,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80
+      ]
     }
   },
   {
@@ -19,11 +58,42 @@
     "name": "sco-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "scotland" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "scotland" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "scotland" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "scotland" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "scotland"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "scotland"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "scotland"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "scotland"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "Scotland",
@@ -35,7 +105,15 @@
     "name": "sco-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "scotland" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Scotland - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -47,7 +125,15 @@
     "name": "sco-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "scotland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Scotland - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -59,7 +145,15 @@
     "name": "sco-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "scotland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Scotland - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -71,7 +165,15 @@
     "name": "sco-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "scotland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Scotland - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -83,7 +185,15 @@
     "name": "aa-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_ayrshire_arran" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Ayrshire & Arran - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -95,7 +205,15 @@
     "name": "aa-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_ayrshire_arran" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Ayrshire & Arran - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -107,7 +225,15 @@
     "name": "aa-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_ayrshire_arran" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Ayrshire & Arran - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -119,10 +245,18 @@
     "name": "aa-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_ayrshire_arran" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
-    "title": "NHS Ayrshire & Arran - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight.",
+    "title": "NHS Ayrshire & Arran - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
     "description": "The number of people in hospital with suspected COVID-19 in NHS Ayrshire & Arran.",
     "links": {}
   },
@@ -131,7 +265,15 @@
     "name": "bpr-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_borders" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_borders"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Borders - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -143,7 +285,15 @@
     "name": "bpr-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_borders" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_borders"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Borders - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -155,7 +305,15 @@
     "name": "bpr-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_borders" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_borders"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Borders - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -167,7 +325,15 @@
     "name": "bpr-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_borders" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_borders"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Borders - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -179,11 +345,19 @@
     "name": "dg-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_dumfries_galloway" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Dumfries & Galloway - Cumulative Number of Cases Tested Positive for COVID-19",
-    "description": "The cumulative number of cases with positive tests for COVID-19 in NHS Dunfries & Galloway.",
+    "description": "The cumulative number of cases with positive tests for COVID-19 in NHS Dumfries & Galloway.",
     "links": {}
   },
   {
@@ -191,7 +365,15 @@
     "name": "dg-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_dumfries_galloway" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Dumfries & Galloway - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -203,7 +385,15 @@
     "name": "dg-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_dumfries_galloway" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Dumfries & Galloway - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -215,7 +405,15 @@
     "name": "dg-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_dumfries_galloway" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Dumfries & Galloway - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -227,7 +425,15 @@
     "name": "fif-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_fife" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_fife"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Fife - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -239,7 +445,15 @@
     "name": "fif-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_fife" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_fife"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Fife - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -251,7 +465,15 @@
     "name": "fif-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_fife" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_fife"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Fife - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -263,7 +485,15 @@
     "name": "fif-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_fife" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_fife"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Fife - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -275,7 +505,15 @@
     "name": "fov-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_forth_valley" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_forth_valley"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Forth Valley - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -287,7 +525,15 @@
     "name": "fov-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_forth_valley" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_forth_valley"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Forth Valley - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -299,7 +545,15 @@
     "name": "fov-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_forth_valley" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_forth_valley"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Forth Valley - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -311,7 +565,15 @@
     "name": "fov-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_forth_valley" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_forth_valley"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Forth Valley - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -323,7 +585,15 @@
     "name": "gc-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_greater_glasgow_clyde" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Greater Glasgow & Clyde - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -335,7 +605,15 @@
     "name": "gc-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_greater_glasgow_clyde" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Greater Glasgow & Clyde - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -347,7 +625,15 @@
     "name": "gc-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_greater_glasgow_clyde" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Greater Glasgow & Clyde - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -359,7 +645,15 @@
     "name": "gc-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_greater_glasgow_clyde" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Greater Glasgow & Clyde - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -371,7 +665,15 @@
     "name": "golden-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "golden_jubilee_nationalhospital" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "golden_jubilee_nationalhospital"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Golden Jubilee National Hospital - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -383,7 +685,15 @@
     "name": "golden-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "golden_jubilee_nationalhospital" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "golden_jubilee_nationalhospital"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Golden Jubilee National Hospital - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -395,7 +705,15 @@
     "name": "golden-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "golden_jubilee_nationalhospital" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "golden_jubilee_nationalhospital"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Golden Jubilee National Hospital - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -407,7 +725,15 @@
     "name": "gra-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_grampian" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_grampian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Grampian - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -419,7 +745,15 @@
     "name": "gra-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_grampian" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_grampian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Grampian - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -431,7 +765,15 @@
     "name": "gra-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_grampian" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_grampian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Grampian - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -443,7 +785,15 @@
     "name": "gra-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_grampian" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_grampian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Grampian - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -455,7 +805,15 @@
     "name": "hig-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_highland" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_highland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Highland - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -467,7 +825,15 @@
     "name": "hig-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_highland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_highland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Highland - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -479,7 +845,15 @@
     "name": "hig-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_highland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_highland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Highland - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -491,7 +865,15 @@
     "name": "hig-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_highland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_highland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Highland - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -503,7 +885,15 @@
     "name": "lan-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_lanarkshire" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_lanarkshire"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lanarkshire - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -515,7 +905,15 @@
     "name": "lan-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_lanarkshire" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_lanarkshire"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lanarkshire - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -527,7 +925,15 @@
     "name": "lan-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_lanarkshire" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_lanarkshire"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lanarkshire - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -539,7 +945,15 @@
     "name": "lan-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_lanarkshire" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_lanarkshire"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lanarkshire - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -551,7 +965,15 @@
     "name": "lot-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_lothian" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_lothian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lothian - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -563,7 +985,15 @@
     "name": "lot-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_lothian" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_lothian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lothian - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -575,7 +1005,15 @@
     "name": "lot-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_lothian" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_lothian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lothian - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -587,7 +1025,15 @@
     "name": "lot-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_lothian" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_lothian"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Lothian - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -599,7 +1045,15 @@
     "name": "ork-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_orkney" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_orkney"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Orkney - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -611,7 +1065,15 @@
     "name": "ork-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_orkney" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_orkney"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Orkney - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -623,7 +1085,15 @@
     "name": "ork-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_orkney" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_orkney"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Orkney - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -635,7 +1105,15 @@
     "name": "ork-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_orkney" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_orkney"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Orkney - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -647,7 +1125,15 @@
     "name": "she-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_shetland" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_shetland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Shetland - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -659,7 +1145,15 @@
     "name": "she-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_shetland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_shetland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Shetland - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -671,7 +1165,15 @@
     "name": "she-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_shetland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_shetland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Shetland - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -683,7 +1185,15 @@
     "name": "she-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_shetland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_shetland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Shetland - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -695,7 +1205,15 @@
     "name": "tay-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_tayside" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_tayside"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Tayside - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -707,7 +1225,15 @@
     "name": "tay-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_tayside" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_tayside"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Tayside - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -719,7 +1245,15 @@
     "name": "tay-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_tayside" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_tayside"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Tayside - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -731,7 +1265,15 @@
     "name": "tay-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_tayside" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_tayside"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Tayside - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -743,7 +1285,15 @@
     "name": "wei-cumulative",
     "type": "plot",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_western_isles_scotland" }, "title": "" }
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Western Isles - Cumulative Number of Cases Tested Positive for COVID-19",
@@ -755,7 +1305,15 @@
     "name": "wei-icu_patients",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_western_isles_scotland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Western Isles - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
@@ -767,7 +1325,15 @@
     "name": "wei-hospconfirmed",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_western_isles_scotland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Western Isles - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
@@ -779,7 +1345,15 @@
     "name": "wei-hospsuspected",
     "type": "plot",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_western_isles_scotland" }, "title": "" }
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "NHS Western Isles - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
@@ -791,11 +1365,42 @@
     "name": "aa-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_ayrshire_arran" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_ayrshire_arran" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_ayrshire_arran" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_ayrshire_arran" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_ayrshire_arran"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Ayrshire & Arran",
@@ -807,11 +1412,42 @@
     "name": "bpr-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_borders" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_borders" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_borders" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_borders" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_borders"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_borders"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_borders"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_borders"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Borders",
@@ -823,11 +1459,42 @@
     "name": "dg-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_dumfries_galloway" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_dumfries_galloway" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_dumfries_galloway" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_dumfries_galloway" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_dumfries_galloway"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Dumfries & Galloway",
@@ -839,11 +1506,42 @@
     "name": "fif-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_fife" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_fife" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_fife" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_fife" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_fife"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_fife"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_fife"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_fife"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Fife",
@@ -855,11 +1553,42 @@
     "name": "fov-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_forth_valley" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_forth_valley" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_forth_valley" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_forth_valley" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_forth_valley"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_forth_valley"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_forth_valley"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_forth_valley"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Forth Valley",
@@ -871,11 +1600,42 @@
     "name": "gc-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_greater_glasgow_clyde" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_greater_glasgow_clyde" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_greater_glasgow_clyde" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_greater_glasgow_clyde" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_greater_glasgow_clyde"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Greater Glasgow & Clyde",
@@ -887,10 +1647,33 @@
     "name": "golden-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "golden_jubilee_nationalhospital" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "golden_jubilee_nationalhospital" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "golden_jubilee_nationalhospital" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "golden_jubilee_nationalhospital"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "golden_jubilee_nationalhospital"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "golden_jubilee_nationalhospital"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 1,
     "title": "Golden Jubilee National Hospital",
@@ -902,11 +1685,42 @@
     "name": "gra-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_grampian" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_grampian" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_grampian" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_grampian" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_grampian"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_grampian"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_grampian"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_grampian"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Grampian",
@@ -918,11 +1732,42 @@
     "name": "hig-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_highland" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_highland" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_highland" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_highland" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_highland"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_highland"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_highland"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_highland"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Highland",
@@ -934,11 +1779,42 @@
     "name": "lan-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_lanarkshire" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_lanarkshire" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_lanarkshire" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_lanarkshire" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_lanarkshire"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_lanarkshire"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_lanarkshire"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_lanarkshire"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Lanarkshire",
@@ -950,11 +1826,42 @@
     "name": "lot-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_lothian" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_lothian" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_lothian" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_lothian" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_lothian"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_lothian"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_lothian"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_lothian"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Lothian",
@@ -966,11 +1873,42 @@
     "name": "ork-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_orkney" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_orkney" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_orkney" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_orkney" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_orkney"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_orkney"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_orkney"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_orkney"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Orkney",
@@ -982,11 +1920,42 @@
     "name": "she-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_shetland" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_shetland" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_shetland" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_shetland" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_shetland"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_shetland"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_shetland"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_shetland"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Shetland",
@@ -998,11 +1967,42 @@
     "name": "tay-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_tayside" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_tayside" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_tayside" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_tayside" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_tayside"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_tayside"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_tayside"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_tayside"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Tayside",
@@ -1014,11 +2014,42 @@
     "name": "wei-regional",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "nhs_western_isles_scotland" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "nhs_western_isles_scotland" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "nhs_western_isles_scotland" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "nhs_western_isles_scotland" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 2,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 2,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "nhs_western_isles_scotland"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "NHS Western Isles",
@@ -1030,18 +2061,107 @@
     "name": "top-level-overview-screen-c",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 4, "data_id": 1, "query_params": { "table": "icu_patients" }, "title": "ICU Patients" },
-      { "vis_id": 4, "data_id": 1, "query_params": { "table": "hospital_confirmed" }, "title": "Hospital Confirmed" },
-      { "vis_id": 4, "data_id": 1, "query_params": { "table": "hospital_suspected" }, "title": "Hospital Suspected" }
+      {
+        "vis_id": 4,
+        "data_id": 1,
+        "query_params": {
+          "table": "icu_patients"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 4,
+        "data_id": 1,
+        "query_params": {
+          "table": "hospital_confirmed"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 4,
+        "data_id": 1,
+        "query_params": {
+          "table": "hospital_suspected"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 1,
     "title": "Coronavirus (COVID-19): Scotland Board-level Daily Data",
     "description": "The number of people in ICU with confirmed or suspected COVID-19 in Scotland. The number of people in the hospital with confirmed COVID-19 in Scotland. The number of people in hospital with suspected COVID-19 in Scotland.",
     "links": {
-                "dashboard": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80, 72],
-                "icu_patients": [4, 8, 12, 16, 20, 24, 35, 28, 39, 43, 47, 51, 55, 59, 63, 31],
-                "hospital_confirmed": [5, 9, 13, 17, 21, 25, 36, 29, 40, 44, 48, 52, 56, 60, 64, 32],
-                "hospital_suspected": [6, 10, 14, 18, 22, 26, 37, 30, 41, 45, 49, 53, 57, 61, 65, 33]
+      "dashboard": [
+        2,
+        66,
+        67,
+        68,
+        69,
+        70,
+        73,
+        71,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        72
+      ],
+      "icu_patients": [
+        4,
+        8,
+        12,
+        16,
+        20,
+        24,
+        35,
+        28,
+        39,
+        43,
+        47,
+        51,
+        55,
+        59,
+        63,
+        31
+      ],
+      "hospital_confirmed": [
+        5,
+        9,
+        13,
+        17,
+        21,
+        25,
+        36,
+        29,
+        40,
+        44,
+        48,
+        52,
+        56,
+        60,
+        64,
+        32
+      ],
+      "hospital_suspected": [
+        6,
+        10,
+        14,
+        18,
+        22,
+        26,
+        37,
+        30,
+        41,
+        45,
+        49,
+        53,
+        57,
+        61,
+        65,
+        33
+      ]
     }
   },
   {
@@ -1049,31 +2169,55 @@
     "name": "pearson-correlation",
     "type": "analytics",
     "bind": [
-      { "vis_id": 5, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "pearson_correlation" }, "title": "" }
+      {
+        "vis_id": 5,
+        "data_id": 4,
+        "query_params": {
+          "table": "cumulative_cases",
+          "metrics": "pearson_correlation"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Cumulative Cases - Pearson Correlation",
     "description": "The cumulative cases using Pearson Correlation",
     "links": {}
   },
-    {
+  {
     "id": 83,
     "name": "mse",
     "type": "analytics",
     "bind": [
-      { "vis_id": 5, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "mse" }, "title": "" }
+      {
+        "vis_id": 5,
+        "data_id": 4,
+        "query_params": {
+          "table": "cumulative_cases",
+          "metrics": "mse"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Cumulative Cases - MSE",
     "description": "The cumulative cases using MSE",
     "links": {}
   },
-    {
+  {
     "id": 84,
     "name": "f-test",
     "type": "analytics",
     "bind": [
-      { "vis_id": 5, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "f_test" }, "title": "" }
+      {
+        "vis_id": 5,
+        "data_id": 4,
+        "query_params": {
+          "table": "cumulative_cases",
+          "metrics": "f_test"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Cumulative Cases - F-Test",
@@ -1085,14 +2229,53 @@
     "name": "dynamic-top-level-overview-screen-a",
     "type": "dynamic",
     "bind": [
-      { "vis_id": 1, "data_id": 5, "query_params": { "table": "cumulative_cases" }, "title": "" }
+      {
+        "vis_id": 1,
+        "data_id": 5,
+        "query_params": {
+          "table": "cumulative_cases"
+        },
+        "title": ""
+      }
     ],
     "nrows": 1,
     "title": "Dynamic - Cumulative Number of Cases Tested Positive for COVID-19",
     "description": "The cumulative number of cases with positive tests for COVID-19, by board in Scotland",
     "links": {
-                "regional": [3, 7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62],
-                "board": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80]
+      "regional": [
+        7,
+        11,
+        15,
+        19,
+        23,
+        34,
+        27,
+        38,
+        42,
+        46,
+        50,
+        54,
+        58,
+        62,
+        3
+      ],
+      "board": [
+        66,
+        67,
+        68,
+        69,
+        70,
+        73,
+        71,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        2
+      ]
     }
   },
   {
@@ -1100,11 +2283,42 @@
     "name": "dynamic-sco-regional",
     "type": "dynamic",
     "bind": [
-      { "vis_id": 3, "data_id": 6, "query_params": { "table": "cumulative_cases", "region": "scotland" }, "title": "Cumulative Number of Cases"},
-      { "vis_id": 2, "data_id": 6, "query_params": { "table": "icu_patients", "region": "scotland" }, "title": "ICU Patients" },
-      { "vis_id": 2, "data_id": 6, "query_params": { "table": "hospital_confirmed", "region": "scotland" }, "title": "Hospital Confirmed" },
-      { "vis_id": 2, "data_id": 6, "query_params": { "table": "hospital_suspected", "region": "scotland" }, "title": "Hospital Suspected" }
-
+      {
+        "vis_id": 3,
+        "data_id": 6,
+        "query_params": {
+          "table": "cumulative_cases",
+          "region": "scotland"
+        },
+        "title": "Cumulative Number of Cases"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 6,
+        "query_params": {
+          "table": "icu_patients",
+          "region": "scotland"
+        },
+        "title": "ICU Patients"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 6,
+        "query_params": {
+          "table": "hospital_confirmed",
+          "region": "scotland"
+        },
+        "title": "Hospital Confirmed"
+      },
+      {
+        "vis_id": 2,
+        "data_id": 6,
+        "query_params": {
+          "table": "hospital_suspected",
+          "region": "scotland"
+        },
+        "title": "Hospital Suspected"
+      }
     ],
     "nrows": 2,
     "title": "Dynamic - Scotland - Overview",
@@ -1116,7 +2330,15 @@
     "name": "weekly-death-situation-stacked-bar-chart",
     "type": "analytics",
     "bind": [
-      { "vis_id": 6, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "location" }, "title": "Weekly deaths by COVID-19 in each situation setting (bar chart)" }
+      {
+        "vis_id": 6,
+        "data_id": 3,
+        "query_params": {
+          "table": "covid_deaths",
+          "group": "location"
+        },
+        "title": "Weekly deaths by COVID-19 in each situation setting (bar chart)"
+      }
     ],
     "nrows": 1,
     "title": "Weekly deaths by COVID-19 in each situation setting (bar chart)",
@@ -1128,7 +2350,15 @@
     "name": "weekly-death-situation-stacked-area-chart",
     "type": "analytics",
     "bind": [
-      { "vis_id": 7, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "location" }, "title": "Weekly deaths by COVID-19 in each situation setting (area chart)" }
+      {
+        "vis_id": 7,
+        "data_id": 3,
+        "query_params": {
+          "table": "covid_deaths",
+          "group": "location"
+        },
+        "title": "Weekly deaths by COVID-19 in each situation setting (area chart)"
+      }
     ],
     "nrows": 1,
     "title": "Weekly deaths by COVID-19 in each situation setting (area chart)",
@@ -1140,7 +2370,15 @@
     "name": "weekly-death-agegroup-gender-stacked-bar-chart",
     "type": "analytics",
     "bind": [
-      { "vis_id": 8, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "gender_age" }, "title": "Weekly deaths by COVID-19 in each age group and gender (bar chart)" }
+      {
+        "vis_id": 8,
+        "data_id": 3,
+        "query_params": {
+          "table": "covid_deaths",
+          "group": "gender_age"
+        },
+        "title": "Weekly deaths by COVID-19 in each age group and gender (bar chart)"
+      }
     ],
     "nrows": 1,
     "title": "Weekly deaths by COVID-19 in each age group and gender (bar chart)",
@@ -1152,7 +2390,15 @@
     "name": "weekly-death-agegroup-gender-stacked-area-chart",
     "type": "analytics",
     "bind": [
-      { "vis_id": 9, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "gender_age" }, "title": "Weekly deaths by COVID-19 in each age group and gender (area chart)" }
+      {
+        "vis_id": 9,
+        "data_id": 3,
+        "query_params": {
+          "table": "covid_deaths",
+          "group": "gender_age"
+        },
+        "title": "Weekly deaths by COVID-19 in each age group and gender (area chart)"
+      }
     ],
     "nrows": 1,
     "title": "Weekly deaths by COVID-19 in each age group and gender (area chart)",
@@ -1164,7 +2410,15 @@
     "name": "weekly-death-cause-comparison",
     "type": "analytics",
     "bind": [
-      { "vis_id": 10, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "type" }, "title": "Weekly comparison of causes of deaths" }
+      {
+        "vis_id": 10,
+        "data_id": 3,
+        "query_params": {
+          "table": "covid_deaths",
+          "group": "type"
+        },
+        "title": "Weekly comparison of causes of deaths"
+      }
     ],
     "nrows": 1,
     "title": "Weekly comparison of causes of deaths.",
@@ -1176,7 +2430,15 @@
     "name": "cumulative-cases-correlation-simple-matrix",
     "type": "analytics",
     "bind": [
-      { "vis_id": 11, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "pearson_correlation" }, "title": "Correlation of cumulative cases between health boards (simple matrix)" }
+      {
+        "vis_id": 11,
+        "data_id": 4,
+        "query_params": {
+          "table": "cumulative_cases",
+          "metrics": "pearson_correlation"
+        },
+        "title": "Correlation of cumulative cases between health boards (simple matrix)"
+      }
     ],
     "nrows": 1,
     "title": "Correlation of cumulative cases between health boards (simple matrix)",
@@ -1188,10 +2450,25 @@
     "name": "cumulative-cases-correlation-complex-matrix",
     "type": "analytics",
     "bind": [
-      { "vis_id": 12, 
-        "data": [ { "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "pearson_correlation" } },
-                  { "data_id": 1, "query_params": { "table": "cumulative_cases" } }], 
-        "title": "Correlation of cumulative cases between health boards (complex matrix)" }
+      {
+        "vis_id": 12,
+        "data": [
+          {
+            "data_id": 4,
+            "query_params": {
+              "table": "cumulative_cases",
+              "metrics": "pearson_correlation"
+            }
+          },
+          {
+            "data_id": 1,
+            "query_params": {
+              "table": "cumulative_cases"
+            }
+          }
+        ],
+        "title": "Correlation of cumulative cases between health boards (complex matrix)"
+      }
     ],
     "nrows": 1,
     "title": "Correlation of cumulative cases between health boards (complex matrix)",
@@ -1203,25 +2480,172 @@
     "name": "scotland",
     "type": "dashboard",
     "bind": [
-      { "vis_id": 13, 
-        "data": [ { "data_id": 1, "query_params": { "table": "cumulative_cases" } },
-                  { "data_id": 1, "query_params": { "table": "hospital_suspected" } },
-                  { "data_id": 1, "query_params": { "table": "hospital_confirmed" } },
-                  { "data_id": 1, "query_params": { "table": "icu_patients" } }], 
-        "title": "" },
-      { "vis_id": 1, "data_id": 1, "query_params": { "table": "cumulative_cases" }, "title": "The cumulative number of cases with positive tests for COVID-19, by board in Scotland" }
+      {
+        "vis_id": 13,
+        "data": [
+          {
+            "data_id": 1,
+            "query_params": {
+              "table": "cumulative_cases"
+            }
+          },
+          {
+            "data_id": 1,
+            "query_params": {
+              "table": "hospital_suspected"
+            }
+          },
+          {
+            "data_id": 1,
+            "query_params": {
+              "table": "hospital_confirmed"
+            }
+          },
+          {
+            "data_id": 1,
+            "query_params": {
+              "table": "icu_patients"
+            }
+          }
+        ],
+        "title": ""
+      },
+      {
+        "vis_id": 1,
+        "data_id": 1,
+        "query_params": {
+          "table": "cumulative_cases"
+        },
+        "title": "The cumulative number of cases with positive tests for COVID-19, by board in Scotland"
+      }
     ],
     "nrows": 1,
     "title": "Scotland",
     "description": "",
     "links": {
-                "dashboard": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80, 72],
-                "cumulative_cases": [3, 7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62],
-                "icu_patients": [4, 8, 12, 16, 20, 24, 35, 28, 39, 43, 47, 51, 55, 59, 63, 31],
-                "hospital_confirmed": [5, 9, 13, 17, 21, 25, 36, 29, 40, 44, 48, 52, 56, 60, 64, 32],
-                "hospital_suspected": [6, 10, 14, 18, 22, 26, 37, 30, 41, 45, 49, 53, 57, 61, 65, 33],
-                "regional": [3, 7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62],
-                "board": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80]
+      "dashboard": [
+        2,
+        66,
+        67,
+        68,
+        69,
+        70,
+        73,
+        71,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        72
+      ],
+      "cumulative_cases": [
+        3,
+        7,
+        11,
+        15,
+        19,
+        23,
+        34,
+        27,
+        38,
+        42,
+        46,
+        50,
+        54,
+        58,
+        62
+      ],
+      "icu_patients": [
+        4,
+        8,
+        12,
+        16,
+        20,
+        24,
+        35,
+        28,
+        39,
+        43,
+        47,
+        51,
+        55,
+        59,
+        63,
+        31
+      ],
+      "hospital_confirmed": [
+        5,
+        9,
+        13,
+        17,
+        21,
+        25,
+        36,
+        29,
+        40,
+        44,
+        48,
+        52,
+        56,
+        60,
+        64,
+        32
+      ],
+      "hospital_suspected": [
+        6,
+        10,
+        14,
+        18,
+        22,
+        26,
+        37,
+        30,
+        41,
+        45,
+        49,
+        53,
+        57,
+        61,
+        65,
+        33
+      ],
+      "regional": [
+        3,
+        7,
+        11,
+        15,
+        19,
+        23,
+        34,
+        27,
+        38,
+        42,
+        46,
+        50,
+        54,
+        58,
+        62
+      ],
+      "board": [
+        2,
+        66,
+        67,
+        68,
+        69,
+        70,
+        73,
+        71,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80
+      ]
     }
   }
 ]

--- a/app/service/database/pages.template
+++ b/app/service/database/pages.template
@@ -1,0 +1,323 @@
+  [
+  {
+    "id": 1,
+    "name": "top-level-overview-screen-a",
+    "type": "dashboard",
+    "bind": [
+      { "vis_id": 1, "data_id": 1, "query_params": { "table": "cumulative_cases" }, "title": "" }
+    ],
+    "nrows": 1,
+    "title": "Cumulative Number of Cases Tested Positive for COVID-19",
+    "description": "The cumulative number of cases with positive tests for COVID-19, by board in Scotland",
+    "links": {
+                "regional": [3, 7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62],
+                "board": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80]
+    }
+  },
+  {
+    "id": 2,
+    "name": "sco-regional",
+    "type": "dashboard",
+    "bind": [
+      { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "scotland" }, "title": "Cumulative Number of Cases"},
+      { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "scotland" }, "title": "ICU Patients" },
+      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "scotland" }, "title": "Hospital Confirmed" },
+      { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "scotland" }, "title": "Hospital Suspected" }
+
+    ],
+    "nrows": 2,
+    "title": "Scotland",
+    "description": "The cumulative number of cases with positive tests for COVID-19 in Scotland. The number of people in ICU with confirmed or suspected COVID-19 in Scotland. The number of people in the hospital with confirmed COVID-19 in Scotland. The number of people in hospital with suspected COVID-19 in Scotland.",
+    "links": {}
+  },
+
+
+{% set count = namespace(value=3) %}
+
+{% for region in regions %}
+
+    {% if region.abbreviation != "golden" %}
+        {
+            "id": {{count.value }},
+            "name": "{{region.abbreviation}}-cumulative",
+            "type": "plot",
+            "bind": [
+              { "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "{{region.shortname}}" }, "title": "" }
+            ],
+            "nrows": 1,
+            "title": "{{region.displayname}} - Cumulative Number of Cases Tested Positive for COVID-19",
+            "description": "The cumulative number of cases with positive tests for COVID-19 in {{region.displayname}}.",
+            "links": {}
+          },
+        {% set count.value = count.value + 1 %}
+    {% endif %}
+
+    {
+      "id": {{count.value }},
+      "name": "{{region.abbreviation}}-icu_patients",
+      "type": "plot",
+      "bind": [
+        { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "{{region.shortname}}" }, "title": "" }
+      ],
+      "nrows": 1,
+      "title": "{{region.displayname}} - Daily Number of COVID-9 Inpatients (Confirmed or Suspected) in ICU at Midnight",
+      "description": "The number of people in ICU with confirmed or suspected COVID-19 in {{region.displayname}}.",
+      "links": {}
+    },
+    {% set count.value = count.value + 1 %}
+
+    {
+      "id": {{count.value }},
+      "name": "{{region.abbreviation}}-hospconfirmed",
+      "type": "plot",
+      "bind": [
+        { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "{{region.shortname}}" }, "title": "" }
+      ],
+      "nrows": 1,
+      "title": "{{region.displayname}} - Daily Number of Confirmed COVID-9 Inpatients in Hospital at Midnight",
+      "description": "The number of people in the hospital with confirmed COVID-19 in {{region.displayname}}.",
+      "links": {}
+    },
+    {% set count.value = count.value + 1 %}
+
+    {
+      "id": {{count.value }},
+      "name": "{{region.abbreviation}}-hospsuspected",
+      "type": "plot",
+      "bind": [
+        { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "{{region.shortname}}" }, "title": "" }
+      ],
+      "nrows": 1,
+      "title": "{{region.displayname}} - Daily Number of Suspected COVID-9 Inpatients in Hospital at Midnight",
+      "description": "The number of people in hospital with suspected COVID-19 in {{region.displayname}}.",
+      "links": {}
+    },
+    {% set count.value = count.value + 1 %}
+
+{% endfor %}
+
+
+
+{% for region in regions %}
+  {% if region.abbreviation != "sco" %}
+      {
+        "id": {{count.value}},
+        "name": "{{region.abbreviation}}-regional",
+        "type": "dashboard",
+        "bind": [
+          {% if region.abbreviation != "golden" %}{ "vis_id": 3, "data_id": 2, "query_params": { "table": "cumulative_cases", "region": "{{region.shortname}}" }, "title": "Cumulative Number of Cases"},{% endif %}
+          { "vis_id": 2, "data_id": 2, "query_params": { "table": "icu_patients", "region": "{{region.shortname}}" }, "title": "ICU Patients" },
+          { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_confirmed", "region": "{{region.shortname}}" }, "title": "Hospital Confirmed" },
+          { "vis_id": 2, "data_id": 2, "query_params": { "table": "hospital_suspected", "region": "{{region.shortname}}" }, "title": "Hospital Suspected" }
+
+        ],
+        "nrows": {{'1' if region.abbreviation == "golden" else '2'}},
+        "title": "{{region.displayname}}",
+        "description": "The cumulative number of cases with positive tests for COVID-19 in {{region.displayname}}. The number of people in ICU with confirmed or suspected COVID-19 in {{region.displayname}}. The number of people in the hospital with confirmed COVID-19 in {{region.displayname}}. The number of people in hospital with suspected COVID-19 in {{region.displayname}}.",
+        "links": {}
+      },
+    {% set count.value = count.value + 1 %}
+  {% endif %}
+{% endfor %}
+
+
+
+  {
+    "id": 81,
+    "name": "top-level-overview-screen-c",
+    "type": "dashboard",
+    "bind": [
+      { "vis_id": 4, "data_id": 1, "query_params": { "table": "icu_patients" }, "title": "ICU Patients" },
+      { "vis_id": 4, "data_id": 1, "query_params": { "table": "hospital_confirmed" }, "title": "Hospital Confirmed" },
+      { "vis_id": 4, "data_id": 1, "query_params": { "table": "hospital_suspected" }, "title": "Hospital Suspected" }
+    ],
+    "nrows": 1,
+    "title": "Coronavirus (COVID-19): Scotland Board-level Daily Data",
+    "description": "The number of people in ICU with confirmed or suspected COVID-19 in Scotland. The number of people in the hospital with confirmed COVID-19 in Scotland. The number of people in hospital with suspected COVID-19 in Scotland.",
+    "links": {
+                "dashboard": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80, 72],
+                "icu_patients": [4, 8, 12, 16, 20, 24, 35, 28, 39, 43, 47, 51, 55, 59, 63, 31],
+                "hospital_confirmed": [5, 9, 13, 17, 21, 25, 36, 29, 40, 44, 48, 52, 56, 60, 64, 32],
+                "hospital_suspected": [6, 10, 14, 18, 22, 26, 37, 30, 41, 45, 49, 53, 57, 61, 65, 33]
+    }
+  },
+  {
+    "id": 82,
+    "name": "pearson-correlation",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 5, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "pearson_correlation" }, "title": "" }
+    ],
+    "nrows": 1,
+    "title": "Cumulative Cases - Pearson Correlation",
+    "description": "The cumulative cases using Pearson Correlation",
+    "links": {}
+  },
+    {
+    "id": 83,
+    "name": "mse",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 5, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "mse" }, "title": "" }
+    ],
+    "nrows": 1,
+    "title": "Cumulative Cases - MSE",
+    "description": "The cumulative cases using MSE",
+    "links": {}
+  },
+    {
+    "id": 84,
+    "name": "f-test",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 5, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "f_test" }, "title": "" }
+    ],
+    "nrows": 1,
+    "title": "Cumulative Cases - F-Test",
+    "description": "The cumulative cases using F-test",
+    "links": {}
+  },
+  {
+    "id": 85,
+    "name": "dynamic-top-level-overview-screen-a",
+    "type": "dynamic",
+    "bind": [
+      { "vis_id": 1, "data_id": 5, "query_params": { "table": "cumulative_cases" }, "title": "" }
+    ],
+    "nrows": 1,
+    "title": "Dynamic - Cumulative Number of Cases Tested Positive for COVID-19",
+    "description": "The cumulative number of cases with positive tests for COVID-19, by board in Scotland",
+    "links": {
+                "regional": [7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62, 3],
+                "board": [66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80, 2]
+    }
+  },
+  {
+    "id": 86,
+    "name": "dynamic-sco-regional",
+    "type": "dynamic",
+    "bind": [
+      { "vis_id": 3, "data_id": 6, "query_params": { "table": "cumulative_cases", "region": "scotland" }, "title": "Cumulative Number of Cases"},
+      { "vis_id": 2, "data_id": 6, "query_params": { "table": "icu_patients", "region": "scotland" }, "title": "ICU Patients" },
+      { "vis_id": 2, "data_id": 6, "query_params": { "table": "hospital_confirmed", "region": "scotland" }, "title": "Hospital Confirmed" },
+      { "vis_id": 2, "data_id": 6, "query_params": { "table": "hospital_suspected", "region": "scotland" }, "title": "Hospital Suspected" }
+    ],
+    "nrows": 2,
+    "title": "Dynamic - Scotland - Overview",
+    "description": "The cumulative number of cases with positive tests for COVID-19 in Scotland. The number of people in ICU with confirmed or suspected COVID-19 in Scotland. The number of people in the hospital with confirmed COVID-19 in Scotland. The number of people in hospital with suspected COVID-19 in Scotland.",
+    "links": {}
+  },
+  {
+    "id": 87,
+    "name": "weekly-death-situation-stacked-bar-chart",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 6, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "location" }, "title": "Weekly deaths by COVID-19 in each situation setting (bar chart)" }
+    ],
+    "nrows": 1,
+    "title": "Weekly deaths by COVID-19 in each situation setting (bar chart)",
+    "description": "Stacked bar chart with bar height corresponding to the number of deaths and coloured by situation.",
+    "links": {}
+  },
+  {
+    "id": 88,
+    "name": "weekly-death-situation-stacked-area-chart",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 7, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "location" }, "title": "Weekly deaths by COVID-19 in each situation setting (area chart)" }
+    ],
+    "nrows": 1,
+    "title": "Weekly deaths by COVID-19 in each situation setting (area chart)",
+    "description": "Stacked area chart with area corresponding to the number of deaths and coloured by situation.",
+    "links": {}
+  },
+  {
+    "id": 89,
+    "name": "weekly-death-agegroup-gender-stacked-bar-chart",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 8, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "gender_age" }, "title": "Weekly deaths by COVID-19 in each age group and gender (bar chart)" }
+    ],
+    "nrows": 1,
+    "title": "Weekly deaths by COVID-19 in each age group and gender (bar chart)",
+    "description": "Stacked bar chart with bar height corresponding to the number of deaths, separated by gender and coloured by age group.",
+    "links": {}
+  },
+  {
+    "id": 90,
+    "name": "weekly-death-agegroup-gender-stacked-area-chart",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 9, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "gender_age" }, "title": "Weekly deaths by COVID-19 in each age group and gender (area chart)" }
+    ],
+    "nrows": 1,
+    "title": "Weekly deaths by COVID-19 in each age group and gender (area chart)",
+    "description": "Stacked area chart with area corresponding to the number of deaths, separated by gender and coloured by age group.",
+    "links": {}
+  },
+  {
+    "id": 91,
+    "name": "weekly-death-cause-comparison",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 10, "data_id": 3, "query_params": { "table": "covid_deaths", "group": "type" }, "title": "Weekly comparison of causes of deaths" }
+    ],
+    "nrows": 1,
+    "title": "Weekly comparison of causes of deaths.",
+    "description": "Comparing deaths caused by COVID-19 and other causes together with average deaths in the past 5 years in a weekly basis.",
+    "links": {}
+  },
+  {
+    "id": 92,
+    "name": "cumulative-cases-correlation-simple-matrix",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 11, "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "pearson_correlation" }, "title": "Correlation of cumulative cases between health boards (simple matrix)" }
+    ],
+    "nrows": 1,
+    "title": "Correlation of cumulative cases between health boards (simple matrix)",
+    "description": "Using a matrix to show correlation of cumulative cases between different health boards.",
+    "links": {}
+  },
+  {
+    "id": 93,
+    "name": "cumulative-cases-correlation-complex-matrix",
+    "type": "analytics",
+    "bind": [
+      { "vis_id": 12,
+        "data": [ { "data_id": 4, "query_params": { "table": "cumulative_cases", "metrics": "pearson_correlation" } },
+                  { "data_id": 1, "query_params": { "table": "cumulative_cases" } }],
+        "title": "Correlation of cumulative cases between health boards (complex matrix)" }
+    ],
+    "nrows": 1,
+    "title": "Correlation of cumulative cases between health boards (complex matrix)",
+    "description": "Using a matrix to show correlation of cumulative cases between different health boards together with additional information.",
+    "links": {}
+  },
+  {
+    "id": 99,
+    "name": "scotland",
+    "type": "dashboard",
+    "bind": [
+      { "vis_id": 13,
+        "data": [ { "data_id": 1, "query_params": { "table": "cumulative_cases" } },
+                  { "data_id": 1, "query_params": { "table": "hospital_suspected" } },
+                  { "data_id": 1, "query_params": { "table": "hospital_confirmed" } },
+                  { "data_id": 1, "query_params": { "table": "icu_patients" } }],
+        "title": "" },
+      { "vis_id": 1, "data_id": 1, "query_params": { "table": "cumulative_cases" }, "title": "The cumulative number of cases with positive tests for COVID-19, by board in Scotland" }
+    ],
+    "nrows": 1,
+    "title": "Scotland",
+    "description": "",
+    "links": {
+                "dashboard": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80, 72],
+                "cumulative_cases": [3, 7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62],
+                "icu_patients": [4, 8, 12, 16, 20, 24, 35, 28, 39, 43, 47, 51, 55, 59, 63, 31],
+                "hospital_confirmed": [5, 9, 13, 17, 21, 25, 36, 29, 40, 44, 48, 52, 56, 60, 64, 32],
+                "hospital_suspected": [6, 10, 14, 18, 22, 26, 37, 30, 41, 45, 49, 53, 57, 61, 65, 33],
+                "regional": [3, 7, 11, 15, 19, 23, 34, 27, 38, 42, 46, 50, 54, 58, 62],
+                "board": [2, 66, 67, 68, 69, 70, 73, 71, 74, 75, 76, 77, 78, 79, 80]
+    }
+  }
+]


### PR DESCRIPTION
Ths removes a considerable amount of duplication, making it easier
to add new types of pages, and reducing the potential for copy/paste
errors.

Jinja2 is already specified in requirements.txt, as it is the
default templating engine used by Flask.