### PR TITLE
Reconfigure yarn dev and .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_JS=http://vis.scrc.uk/api/v1
+NEXT_PUBLIC_API_PY=http://vis.scrc.uk/stat/v1

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,0 @@
-PORT=5000
-NEXT_PUBLIC_API_PY=http://localhost:3000/stat/v1
-NEXT_PUBLIC_API_JS=http://localhost:2000/api/v1
-NEXT_PUBLIC_UI_URL=http://localhost:5000

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,0 @@
-PORT=5000
-NEXT_PUBLIC_API_PY=http://vis.scrc.uk/stat/v1
-NEXT_PUBLIC_API_JS=http://vis.scrc.uk/api/v1
-NEXT_PUBLIC_UI_URL=http://vis.scrc.uk

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 # misc
 .DS_Store
 .eslintcache
-/.env
 /.env.local
 /.env.development.local
 /.env.test.local

--- a/.prettierignore
+++ b/.prettierignore
@@ -37,7 +37,6 @@ public/_redirects
 # misc
 .DS_Store
 .eslintcache
-/.env
 /.env.local
 /.env.development.local
 /.env.test.local

--- a/README.md
+++ b/README.md
@@ -24,21 +24,30 @@ Install the dependencies.
 yarn install
 ```
 
-Run the app in development mode using local development APIs (you need to start the development instances of the API server).
+Run the app in development mode using production APIs (you don’t need to start the development instances of the API endpoints).
 
 ```sh
 yarn dev
 ```
 
-Run the app in development mode using production APIs (you don't need to start the development instances of the API server).
+While the web server is running, you can open [http://localhost:5000](http://localhost:5000) in your browser to view the app.
+To stop the server, press `CTRL+C` in the terminal.
 
-```sh
-yarn dev-prod
+---
+
+If you want to use local API endpoints instead of the default remote ones, create a new file called `.env.local` with the following contents:
+
+```ini
+NEXT_PUBLIC_API_JS=http://localhost:2000/api/v1
+NEXT_PUBLIC_API_PY=http://localhost:3000/stat/v1
 ```
 
-Open [http://localhost:5000](http://localhost:5000) to view it in the browser.
+The URLs may differ from the examples above depending on your server settings.
+
+Note that you need to restart the server (`yarn dev`) for the changes to take effect.
+See [Next.js docs → Environment Variables](https://nextjs.org/docs/basic-features/environment-variables) for more info.
 
 ## References
 
-- Bootstrapped [Next.js](https://github.com/vercel/next.js)
+- Bootstrapped with [Next.js](https://github.com/vercel/next.js)
 - Using [React material dashboard style](https://material-ui.com)

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev-prod": "env-cmd -f .env.production next dev",
-    "dev": "env-cmd -f .env.development next dev",
+    "dev": "next dev --port 5000",
     "fix:eslint": "next lint --fix",
     "fix:prettier": "prettier --write \"**/*\"",
     "fix:yarn-deduplicate": "yarn install; yarn-deduplicate --strategy=fewer; yarn install",
@@ -71,7 +70,6 @@
     "@types/react-draft-wysiwyg": "^1.13.3",
     "@types/yup": "^0.29.13",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
-    "env-cmd": "^10.1.0",
     "eslint": "^7.32.0",
     "eslint-config-next": "11.1.0",
     "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,11 +1578,6 @@ commander@2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
 commander@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
@@ -1701,7 +1696,7 @@ create-react-class@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2237,14 +2232,6 @@ enquirer@^2.3.5, enquirer@^2.3.6:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
-
-env-cmd@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
-  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
-  dependencies:
-    commander "^4.0.0"
-    cross-spawn "^7.0.0"
 
 error-ex@^1.3.1:
   version "1.3.2"


### PR DESCRIPTION
This PR follows the today’s conversation with @saifulkhan and @phongvis.

- We use `yarn dev` as a single entry point for running the local dev server.
- We use production API endpoints by default (this can change later if we introduce staging server). UI devs end up with s simpler onboarding process.
- To switch to local API servers, a developer should create `.env.local` and define `localhost` URLs. The file is not tracked by git, unlike `.env`. This approach matches [Next.js docs](https://nextjs.org/docs/basic-features/environment-variables).

Out of scope:
- Switching from port 5000 to 3000 (we need to change the default API server port first).
- Configuring `yarn build`.