### PR TITLE
Switch to port 3000 (community default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run the app in development mode using production APIs (you don’t need to start
 yarn dev
 ```
 
-While the web server is running, you can open [http://localhost:5000](http://localhost:5000) in your browser to view the app.
+While the web server is running, you can open [http://localhost:3000](http://localhost:3000) in your browser to view the app.
 To stop the server, press `CTRL+C` in the terminal.
 
 ---
@@ -38,8 +38,8 @@ To stop the server, press `CTRL+C` in the terminal.
 If you want to use local API endpoints instead of the default remote ones, create a new file called `.env.local` with the following contents:
 
 ```ini
-NEXT_PUBLIC_API_JS=http://localhost:2000/api/v1
-NEXT_PUBLIC_API_PY=http://localhost:3000/stat/v1
+NEXT_PUBLIC_API_JS=http://localhost:4000/api/v1
+NEXT_PUBLIC_API_PY=http://localhost:4010/stat/v1
 ```
 
 The URLs may differ from the examples above depending on your server settings.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev --port 5000",
+    "dev": "next dev",
     "fix:eslint": "next lint --fix",
     "fix:prettier": "prettier --write \"**/*\"",
     "fix:yarn-deduplicate": "yarn install; yarn-deduplicate --strategy=fewer; yarn install",

--- a/src/lib/vis/country-overview.js
+++ b/src/lib/vis/country-overview.js
@@ -28,7 +28,7 @@ import {
 
 var nhsBoardField = "";
 var latestUpdateTime = "";
-//http://localhost:5000/608c2945051751537fab92d1
+//http://localhost:3000/608c2945051751537fab92d1
 
 export class CountryOverview {
   CHART_WIDTH = 1000;


### PR DESCRIPTION
This PR migrates the app from port 5000 to 3000, thus switching us to a commonly used default value. We can merge the changes after changing default ports in https://github.com/ScottishCovidResponse/rampvis-api.