### PR TITLE
Stop using prop-types, add ESLint rule to prevent new occurrences

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,13 @@
     "no-param-reassign": "off",
     "no-plusplus": "off",
     "no-return-assign": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "name": "prop-types",
+        "message": "Please add TypeScript typings to props instead."
+      }
+    ],
     "object-curly-newline": "off",
     "react/forbid-prop-types": "off",
     "react/jsx-filename-extension": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
-{
-  "plugins": ["@typescript-eslint"],
-  "extends": ["next", "plugin:@typescript-eslint/recommended", "prettier"],
-  "rules": {
+module.exports = {
+  plugins: ["@typescript-eslint"],
+  extends: ["next", "plugin:@typescript-eslint/recommended", "prettier"],
+  rules: {
     "@typescript-eslint/comma-dangle": "off",
     "class-methods-use-this": "off",
     "comma-dangle": "off",
@@ -18,9 +18,9 @@
     "no-restricted-imports": [
       "error",
       {
-        "name": "prop-types",
-        "message": "Please add TypeScript typings to props instead."
-      }
+        name: "prop-types",
+        message: "Please add TypeScript typings to props instead.",
+      },
     ],
     "object-curly-newline": "off",
     "react/forbid-prop-types": "off",
@@ -31,9 +31,9 @@
     "@typescript-eslint/no-this-alias": [
       "error",
       {
-        "allowDestructuring": true,
-        "allowedNames": ["_this"]
-      }
-    ]
-  }
-}
+        allowDestructuring: true,
+        allowedNames: ["_this"],
+      },
+    ],
+  },
+};

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,6 @@
 #!/bin/sh
+if [ -n "$NF_IMAGE_TAG" ]; then exit 0; fi ## Skip on Netlify
+
 . "$(dirname "$0")/_/husky.sh"
 
 yarn install

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@
 !*.yml
 
 # folders with . (compensates *.*)
+!.*
 !*.*/
 
 # special cases

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,21 +2,17 @@
 ## Prettier-specific
 ####################
 
-# extensions
+# Ignore all extensions (folders with . are allowed)
 *.*
-!*.js
+!.*/
+!*.*/
+
+# Allow certain extensions
 !*.json
 !*.md
 !*.ts
 !*.tsx
 !*.yml
-
-# folders with . (compensates *.*)
-!.*
-!*.*/
-
-# special cases
-public/_redirects
 
 ########################
 ## Same as in .gitignore

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "moment": "^2.29.1",
     "next": "^12.0.1",
     "nprogress": "^0.2.0",
-    "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-apexcharts": "^1.3.9",
     "react-beautiful-dnd": "^13.1.0",

--- a/src/components/Bookmark.tsx
+++ b/src/components/Bookmark.tsx
@@ -4,7 +4,6 @@ import { FC, useCallback, useState, useEffect } from "react";
 import { makeStyles } from "@mui/styles";
 import { createStyles, IconButton, Theme } from "@mui/material";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
-import PropTypes from "prop-types";
 import { orange, grey } from "@mui/material/colors";
 import ShowHideGuard from "src/components/auth/guards/ShowHideGuard";
 import { apiService } from "src/utils/apiService";
@@ -57,10 +56,6 @@ const Bookmark: FC<any> = ({ pageId }) => {
       </IconButton>
     </ShowHideGuard>
   );
-};
-
-Bookmark.propTypes = {
-  pageId: PropTypes.any,
 };
 
 export default Bookmark;

--- a/src/components/auth/guards/AuthGuard.tsx
+++ b/src/components/auth/guards/AuthGuard.tsx
@@ -2,7 +2,6 @@ import type { FC, ReactNode } from "react";
 import { useState } from "react";
 // import { Navigate, useLocation } from 'react-router-dom';
 import { useRouter } from "next/router";
-import PropTypes from "prop-types";
 import useAuth from "src/hooks/useAuth";
 import Login from "src/pages/auth/login";
 
@@ -42,10 +41,6 @@ const AuthGuard: FC<AuthGuardProps> = (props) => {
   }
 
   return <>{children}</>;
-};
-
-AuthGuard.propTypes = {
-  children: PropTypes.node,
 };
 
 export default AuthGuard;

--- a/src/components/auth/guards/GuestGuard.tsx
+++ b/src/components/auth/guards/GuestGuard.tsx
@@ -1,6 +1,5 @@
 import type { FC, ReactNode } from "react";
 import { useRouter } from "next/router";
-import PropTypes from "prop-types";
 import useAuth from "src/hooks/useAuth";
 
 interface GuestGuardProps {
@@ -17,10 +16,6 @@ const GuestGuard: FC<GuestGuardProps> = ({ children }) => {
   }
 
   return <>{children}</>;
-};
-
-GuestGuard.propTypes = {
-  children: PropTypes.node,
 };
 
 export default GuestGuard;

--- a/src/components/auth/guards/ShowHideGuard.tsx
+++ b/src/components/auth/guards/ShowHideGuard.tsx
@@ -1,5 +1,4 @@
 import type { FC, ReactNode } from "react";
-import PropTypes from "prop-types";
 import useAuth from "src/hooks/useAuth";
 
 interface ShowHideGuardProps {
@@ -14,10 +13,6 @@ const ShowHideGuard: FC<ShowHideGuardProps> = ({ children }) => {
   }
 
   return <>{children}</>;
-};
-
-ShowHideGuard.propTypes = {
-  children: PropTypes.node,
 };
 
 export default ShowHideGuard;

--- a/src/components/dashboard-layout/DashboardNavbar.tsx
+++ b/src/components/dashboard-layout/DashboardNavbar.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react";
-import PropTypes from "prop-types";
 import { AppBar, Box, IconButton, Toolbar, AppBarProps } from "@mui/material";
 import { experimentalStyled } from "@mui/material/styles";
 import MenuIcon from "@mui/icons-material//Menu";
@@ -78,10 +77,6 @@ const DashboardNavbar: FC<DashboardNavbarProps> = (props) => {
       </Toolbar>
     </DashboardNavbarRoot>
   );
-};
-
-DashboardNavbar.propTypes = {
-  onSidebarMobileOpen: PropTypes.func,
 };
 
 export default DashboardNavbar;

--- a/src/components/dashboard-layout/DashboardSidebar.tsx
+++ b/src/components/dashboard-layout/DashboardSidebar.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import type { FC } from "react";
 import { useRouter } from "next/router";
-import PropTypes from "prop-types";
 import { Box, Divider, Drawer, Typography } from "@mui/material";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
@@ -249,11 +248,6 @@ const DashboardSidebar: FC<DashboardSidebarProps> = ({
       {content}
     </Drawer>
   );
-};
-
-DashboardSidebar.propTypes = {
-  onMobileClose: PropTypes.func,
-  openMobile: PropTypes.bool,
 };
 
 export default DashboardSidebar;

--- a/src/components/dashboard-layout/NavItem.tsx
+++ b/src/components/dashboard-layout/NavItem.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import type { FC, ReactNode } from "react";
-import PropTypes from "prop-types";
 import { Box, Button, Collapse, ListItem, ListItemProps } from "@mui/material";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
@@ -17,19 +16,17 @@ interface NavItemProps extends ListItemProps {
   title: string;
 }
 
-const NavItem: FC<NavItemProps> = (props) => {
-  const {
-    active,
-    children,
-    depth,
-    icon,
-    info,
-    open: openProp,
-    path,
-    title,
-    ...other
-  } = props;
-
+const NavItem: FC<NavItemProps> = ({
+  active = false,
+  children,
+  depth,
+  icon,
+  info,
+  open: openProp = false,
+  path,
+  title,
+  ...rest
+}) => {
   const [open, setOpen] = useState<boolean>(openProp);
 
   const handleToggle = (): void => {
@@ -51,7 +48,7 @@ const NavItem: FC<NavItemProps> = (props) => {
           display: "block",
           py: 0,
         }}
-        {...other}
+        {...rest}
       >
         <Button
           endIcon={
@@ -123,22 +120,6 @@ const NavItem: FC<NavItemProps> = (props) => {
       </NavLink>
     </ListItem>
   );
-};
-
-NavItem.propTypes = {
-  active: PropTypes.bool,
-  children: PropTypes.node,
-  depth: PropTypes.number.isRequired,
-  icon: PropTypes.node,
-  info: PropTypes.node,
-  open: PropTypes.bool,
-  path: PropTypes.string,
-  title: PropTypes.string.isRequired,
-};
-
-NavItem.defaultProps = {
-  active: false,
-  open: false,
 };
 
 export default NavItem;

--- a/src/components/dashboard-layout/NavSection.tsx
+++ b/src/components/dashboard-layout/NavSection.tsx
@@ -1,5 +1,4 @@
 import type { FC, ReactNode } from "react";
-import PropTypes from "prop-types";
 // import { matchPath } from 'react-router-dom';
 import { matchPath } from "src/utils/matchPath";
 
@@ -130,12 +129,6 @@ const NavSection: FC<NavSectionProps> = (props) => {
       })}
     </List>
   );
-};
-
-NavSection.propTypes = {
-  items: PropTypes.array,
-  pathname: PropTypes.string,
-  title: PropTypes.string,
 };
 
 export default NavSection;

--- a/src/components/main-layout/MainLayout.tsx
+++ b/src/components/main-layout/MainLayout.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import type { FC, ReactNode } from "react";
-import PropTypes from "prop-types";
 import { experimentalStyled } from "@mui/material";
 import Footer from "../Footer";
 import MainNavbar from "./MainNavbar";
@@ -23,10 +22,6 @@ const MainLayout: FC<MainLayoutProps> = ({ children }) => {
       <Footer />
     </MainLayoutRoot>
   );
-};
-
-MainLayout.propTypes = {
-  children: PropTypes.node,
 };
 
 export default MainLayout;

--- a/src/components/main-layout/MainNavbar.tsx
+++ b/src/components/main-layout/MainNavbar.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react";
-import PropTypes from "prop-types";
 import Link from "next/link";
 import { AppBar, Box, Button, Divider, Toolbar } from "@mui/material";
 import Logo from "src/components/Logo";
@@ -59,10 +58,6 @@ const MainNavbar: FC<MainNavbarProps> = (props) => {
       <Divider />
     </AppBar>
   );
-};
-
-MainNavbar.propTypes = {
-  onSidebarMobileOpen: PropTypes.func,
 };
 
 export default MainNavbar;

--- a/src/contexts/AuthProviderJWT.tsx
+++ b/src/contexts/AuthProviderJWT.tsx
@@ -1,6 +1,5 @@
 import { createContext, useEffect, useReducer } from "react";
 import type { FC, ReactNode } from "react";
-import PropTypes from "prop-types";
 import jwt_decode from "jwt-decode";
 import { useRouter } from "next/router";
 import type { User } from "src/types/user";
@@ -204,10 +203,6 @@ export const AuthProviderJWT: FC<AuthProviderProps> = (props) => {
       {children}
     </AuthContext.Provider>
   );
-};
-
-AuthProviderJWT.propTypes = {
-  children: PropTypes.node.isRequired,
 };
 
 export default AuthContext;

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, useEffect, useState } from "react";
 import type { FC, ReactNode } from "react";
-import PropTypes from "prop-types";
 import { THEMES } from "../constants";
 
 interface Settings {
@@ -92,10 +91,6 @@ export const SettingsProvider: FC<SettingsProviderProps> = (props) => {
       {children}
     </SettingsContext.Provider>
   );
-};
-
-SettingsProvider.propTypes = {
-  children: PropTypes.node.isRequired,
 };
 
 export const SettingsConsumer = SettingsContext.Consumer;


### PR DESCRIPTION
We don’t need `Component.propTypes = {}` because we use TypeScript. By not importing `"prop-types"` we reduce runtime and save ourselves from avoidable code repetition.