### PR TITLE
Improve data loading feedback in Gridded Glyphs

### DIFF
--- a/src/components/DemographicsDashboard/shared/geoMapLayers/=griddedGlyphs/GriddedGlyphsLayerView.tsx
+++ b/src/components/DemographicsDashboard/shared/geoMapLayers/=griddedGlyphs/GriddedGlyphsLayerView.tsx
@@ -15,6 +15,23 @@ import { unstable_batchedUpdates } from "react-dom";
 
 const dataPointDisplaySize = 2;
 
+const AnimatedEllipsis: React.VoidFunctionComponent = () => {
+  const [count, setCount] = React.useState(3);
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setCount((oldCount) => (oldCount + 1) % 4);
+    }, 500);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+  return (
+    <span style={{ display: "inline-block", width: "1em" }}>
+      {".".repeat(count)}
+    </span>
+  );
+};
+
 const GriddedGlyphsLayerView: GeoMapLayerView<GriddedGlyphsLayerConfig> = ({
   layerConfig,
   onLayerConfigChange,
@@ -223,7 +240,10 @@ const GriddedGlyphsLayerView: GeoMapLayerView<GriddedGlyphsLayerConfig> = ({
             background: "#fffc",
           }}
         >
-          <Typography>preparing data...</Typography>
+          <Typography>
+            preparing data
+            <AnimatedEllipsis />
+          </Typography>
         </Box>
       ) : undefined}
     </>


### PR DESCRIPTION
- [x] Indicator with text
- [x] Old view is preserved while new data is being prepared (this helps spot subtle vis updates)

Preview: https://deploy-preview-161--rampvis-ui-development.netlify.app/tools/gridded-glyphs

<img width="1076" alt="Screenshot 2022-01-28 at 01 35 19 (2)" src="https://user-images.githubusercontent.com/608862/151472484-8c44c4b6-f472-43e9-8551-aaa305f32908.png">

<img width="1079" alt="Screenshot 2022-01-28 at 01 35 56 (2)" src="https://user-images.githubusercontent.com/608862/151472642-359236ab-4348-4726-b418-58eb4955dc15.png">

