### PR TITLE
Fix position of `/tools/gridded-glyphs` on small screens

### DIFF
--- a/src/pages/tools/gridded-glyphs/index.tsx
+++ b/src/pages/tools/gridded-glyphs/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import DashboardLayout from "src/components/dashboard-layout/DashboardLayout";
 import Head from "next/head";
 import DemographicsDashboard from "src/components/DemographicsDashboard";
+import { Box } from "@mui/material";
 
 const GriddedGlyphs = () => {
   return (
@@ -10,19 +11,18 @@ const GriddedGlyphs = () => {
         <title>Gridded glyphs</title>
       </Head>
       <DashboardLayout>
-        <div
-          // TODO: Fix styles for mobile (remove left 280 or change approach)
-          style={{
+        <Box
+          sx={{
             position: "fixed",
             overflow: "visible",
             bottom: 0,
-            left: 280,
+            left: { xs: 0, md: 280 },
             top: 60,
             right: 0,
           }}
         >
           <DemographicsDashboard />
-        </div>
+        </Box>
       </DashboardLayout>
     </>
   );


### PR DESCRIPTION
  
## Before

https://user-images.githubusercontent.com/608862/151768505-a7915e24-284b-493c-b530-f16b89834b91.mp4


## After

https://user-images.githubusercontent.com/608862/151768509-a90f2b97-7b93-4379-8951-a7a779f9e103.mp4

 